### PR TITLE
Set required GC build to 280

### DIFF
--- a/src/main/java/stevekung/mods/moreplanets/core/MorePlanetsMod.java
+++ b/src/main/java/stevekung/mods/moreplanets/core/MorePlanetsMod.java
@@ -57,7 +57,7 @@ public class MorePlanetsMod
     public static final String VERSION = MorePlanetsMod.MAJOR_VERSION + "." + MorePlanetsMod.MINOR_VERSION + "." + MorePlanetsMod.BUILD_VERSION;
     private static final String FORGE_VERSION = "after:forge@[14.23.5.2768,); ";
     private static final String DEPENDENCIES = "after:jei@[4.15.0.268,); ";
-    protected static final String MAIN_DEPENDENCIES = "required-after:stevekung's_lib@[1.1.9,); required-after:galacticraftcore@[4.0.1.-1,); required-after:galacticraftplanets@[4.0.1.-1,); required-after:micdoodlecore; " + MorePlanetsMod.FORGE_VERSION + MorePlanetsMod.DEPENDENCIES;
+    protected static final String MAIN_DEPENDENCIES = "required-after:stevekung's_lib@[1.1.9,); required-after:galacticraftcore@[4.0.1.280,); required-after:galacticraftplanets@[4.0.1.280,); required-after:micdoodlecore; " + MorePlanetsMod.FORGE_VERSION + MorePlanetsMod.DEPENDENCIES;
     public static final String URL = "https://www.curseforge.com/minecraft/mc-mods/more-planets-gc-addon";
     protected static final String JSON_URL = "https://raw.githubusercontent.com/SteveKunG/VersionCheckLibrary/master/more_planets_version.json";
     public static boolean isDevelopment;


### PR DESCRIPTION
Since the 281 build breaks dungeon boss spawns, Players cannot use newer version with lower GC build